### PR TITLE
ObserveAction with current state

### DIFF
--- a/ReduxSimple/ActionDispatched.cs
+++ b/ReduxSimple/ActionDispatched.cs
@@ -3,18 +3,22 @@
     internal abstract class ActionDispatched
     {
         public object Action { get; }
+        
+        public object StateWhenDispatched { get; }
 
-        protected ActionDispatched(object action)
+        protected ActionDispatched(object action, object state)
         {
             Action = action;
+            StateWhenDispatched = state;
         }
     }
 
     internal sealed class ActionDispatchedWithOrigin : ActionDispatched
     {
         public ActionOrigin Origin { get; }
-
-        public ActionDispatchedWithOrigin(object action, ActionOrigin origin) : base(action)
+        
+        public ActionDispatchedWithOrigin(object action, object state, ActionOrigin origin) 
+            : base(action, state)
         {
             Origin = origin;
         }
@@ -24,7 +28,8 @@
     {
         public bool RewriteHistory { get; }
 
-        public ActionDispatchedWithRewriteHistory(object action, bool rewriteHistory) : base(action)
+        public ActionDispatchedWithRewriteHistory(object action, object state, bool rewriteHistory) 
+            : base(action, state)
         {
             RewriteHistory = rewriteHistory;
         }

--- a/ReduxSimple/ReduxStore.TimeTravel.cs
+++ b/ReduxSimple/ReduxStore.TimeTravel.cs
@@ -82,7 +82,7 @@ namespace ReduxSimple
                 return false;
             }
 
-            ExecuteDispatch(new ActionDispatchedWithRewriteHistory(_futureActions.Pop(), false));
+            ExecuteDispatch(new ActionDispatchedWithRewriteHistory(_futureActions.Pop(), State, false));
 
             return true;
         }


### PR DESCRIPTION
Overload for `ObserveAction` that allows the observers to get the state at the point when the action was dispatched.

Use case:
Action `ChangeNameAction`
Action observer that persists the user object with the new changed name into a file. The handler needs the state at the point in time when the action was dispatched.

Note that the handler cannot just simply get `Store.State` because it might have changed in the meanwhile (action observers might get called asynchronously or on different threads).

I added an overload so that previous usages of `ObserveAction` remain valid (backwards compatibility).